### PR TITLE
Implement resync and add it to the job

### DIFF
--- a/src/main/java/com/ays/theatre/crawler/TheatreCrawlerApplication.java
+++ b/src/main/java/com/ays/theatre/crawler/TheatreCrawlerApplication.java
@@ -3,24 +3,34 @@ package com.ays.theatre.crawler;
 import java.time.OffsetDateTime;
 
 import com.ays.theatre.crawler.calendar.base.GoogleCalendarService;
+import com.ays.theatre.crawler.calendar.resync.GoogleCalendarReSyncService;
 import com.ays.theatre.crawler.theatreartbg.job.TheatreArtBgRunner;
 
 import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
 import jakarta.inject.Inject;
 
 //@QuarkusMain(name="TheatreCrawlerApplication")
 public class TheatreCrawlerApplication implements QuarkusApplication {
 
-    @Inject
-    TheatreArtBgRunner theatreArtBgJob;
+    private final TheatreArtBgRunner theatreArtBgJob;
+    private final GoogleCalendarService googleCalendarService;
+    private final GoogleCalendarReSyncService googleCalendarReSyncService;
 
-    @Inject
-    GoogleCalendarService googleCalendarService;
+    public TheatreCrawlerApplication(TheatreArtBgRunner theatreArtBgJob,
+                                     GoogleCalendarService googleCalendarService,
+                                     GoogleCalendarReSyncService googleCalendarReSyncService) {
+        this.theatreArtBgJob = theatreArtBgJob;
+        this.googleCalendarService = googleCalendarService;
+        this.googleCalendarReSyncService = googleCalendarReSyncService;
+    }
 
     @Override
     public int run(String... args) {
         var allEvents = googleCalendarService.getAllEvents(OffsetDateTime.now());
         googleCalendarService.delete(allEvents);
+
+        googleCalendarReSyncService.reSync();
 
         theatreArtBgJob.run();
 

--- a/src/main/java/com/ays/theatre/crawler/calendar/base/GoogleCalendarDescriptionFormatter.java
+++ b/src/main/java/com/ays/theatre/crawler/calendar/base/GoogleCalendarDescriptionFormatter.java
@@ -15,6 +15,8 @@ public class GoogleCalendarDescriptionFormatter {
             """;
 
     private static final String HTML_TEMPLATE = """
+            Последно обвновено: <b class="last_sync_time">%s</b>
+            <br/>
             <a class="play_link" href="%s">theatre.art.bg</a>
             <br/>
             %s
@@ -23,8 +25,6 @@ public class GoogleCalendarDescriptionFormatter {
             <b class="title">%s</b><b class="rating">%s</b>
             <br/>
             <div class="description">%s</div>
-            <br/>
-            Последно обвновено: <b class="last_sync_time">%s</b>
             """;
 
     public static String getHtmlEventDescription(ImmutableGoogleCalendarEventSchedulerPayload payload) {
@@ -33,12 +33,12 @@ public class GoogleCalendarDescriptionFormatter {
                 .orElse("");
 
         return String.format(HTML_TEMPLATE,
+                             payload.getLastUpdated().toString(),
                              payload.getUrl(),
                              theatreArtBgTicketLink,
                              payload.getCrew(),
                              payload.getTitle(), payload.getRating(),
-                             payload.getDescription(),
-                             payload.getLastUpdated().toString());
+                             payload.getDescription());
     }
 
 }

--- a/src/main/java/com/ays/theatre/crawler/calendar/resync/GoogleCalendarReSyncService.java
+++ b/src/main/java/com/ays/theatre/crawler/calendar/resync/GoogleCalendarReSyncService.java
@@ -3,6 +3,7 @@ package com.ays.theatre.crawler.calendar.resync;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 
+import org.jboss.logging.Logger;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -10,9 +11,10 @@ import org.jsoup.nodes.Element;
 import com.ays.theatre.crawler.calendar.base.GoogleCalendarService;
 import com.ays.theatre.crawler.calendar.dao.GoogleCalendarDao;
 import com.ays.theatre.crawler.calendar.model.ImmutableGoogleCalendarEventSchedulerPayload;
-import com.ays.theatre.crawler.core.dao.TheatrePlayDao;
 import com.ays.theatre.crawler.core.model.ImmutableResycRecord;
+import com.ays.theatre.crawler.core.utils.Constants;
 import com.ays.theatre.crawler.core.utils.DateUtils;
+import com.ays.theatre.crawler.core.utils.Origin;
 import com.ays.theatre.crawler.tables.records.TheatrePlayDetailsRecord;
 import com.ays.theatre.crawler.tables.records.TheatrePlayRecord;
 import com.google.api.services.calendar.model.Event;
@@ -21,6 +23,8 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class GoogleCalendarReSyncService {
+    private static final Logger LOG = Logger.getLogger(GoogleCalendarReSyncService.class);
+
     public static final String PLAY_LINK = "play_link";
     public static final String CREW = "crew";
     public static final String RATING = "rating";
@@ -36,12 +40,19 @@ public class GoogleCalendarReSyncService {
         this.dao = dao;
     }
 
-    public void resync() {
-
+    public void reSync() {
+        var numberOfEvents = dao.getNumberOfEvents();
+        if (numberOfEvents > 0) {
+            return;
+        }
+        var allEvents = googleCalendarService.getAllEvents(OffsetDateTime.now());
+        var records = allEvents.stream().map(this::getRecordPair).toList();
+        dao.insertRecords(records);
     }
 
-    public ImmutableResycRecord getRecordPair(Event event, String origin) {
+    public ImmutableResycRecord getRecordPair(Event event) {
         var eventPayload = eventToTheatreRecords(event);
+        var origin = getOriginFromUrl(eventPayload.getUrl());
         var playRecord = new TheatrePlayRecord()
                 .setUrl(eventPayload.getUrl())
                 .setTheatre(eventPayload.getTheatre())
@@ -66,31 +77,43 @@ public class GoogleCalendarReSyncService {
 
     public ImmutableGoogleCalendarEventSchedulerPayload eventToTheatreRecords(Event event) {
         var doc = Jsoup.parse(event.getDescription());
+        var lastSyncTime = getMaybeElement(doc, LAST_SYNC_TIME).map(Element::text).map(OffsetDateTime::parse);
+        if (lastSyncTime.isEmpty()) {
+            LOG.warn(String.format("No last sync time for event %s: %s @ %s", event.getId(), event.getSummary(),
+                                   event.getStart().toString()));
+        }
         return ImmutableGoogleCalendarEventSchedulerPayload.builder()
                 .title(event.getSummary())
                 .theatre(event.getLocation())
                 .startTime(DateUtils.toOffsetDateTime(event.getStart()))
-                .url(getElement(doc, PLAY_LINK).text())
+                .url(getPlayLink(doc))
                 .crew(getElement(doc, CREW).html())
                 .rating(getElement(doc, RATING).text())
-                .lastUpdated(OffsetDateTime.parse(getElement(doc, LAST_SYNC_TIME).text()))
+                .lastUpdated(lastSyncTime.orElseGet(OffsetDateTime::now))
                 .description(getElement(doc, DESCRIPTION).html())
                 .theatreArtBgTicket(getMaybeElement(doc, THEATRE_ART_BG_TICKET_URL).map(Element::html))
                 .build();
     }
 
+    private String getPlayLink(Document doc) {
+        return getElement(doc, PLAY_LINK).attributes().get("href");
+    }
+
+    private String getOriginFromUrl(String url) {
+        if (url.startsWith(Constants.THEATRE_ART_BG_BASE_URL)) {
+            return Origin.THEATRE_ART_BG.getOrigin();
+        }
+        throw new RuntimeException("Unknown origin for " + url);
+    }
+
     private Element getElement(Document doc, String elementClass) {
-        var elements = doc.getElementsByClass(elementClass);
+        var elements = getMaybeElement(doc, elementClass);
         if (elements.isEmpty()) {
             throw new RuntimeException(String.format("No element with class %s found. Exactly one expected",
                                                      elementClass));
         }
-        if (elements.size() > 1) {
-            throw new RuntimeException(String.format("More than one %s class found. Exactly one expected",
-                                                     elementClass));
-        }
 
-        return elements.getFirst();
+        return elements.get();
     }
 
     private Optional<Element> getMaybeElement(Document doc, String elementClass) {

--- a/src/main/java/com/ays/theatre/crawler/core/dao/TheatrePlayDao.java
+++ b/src/main/java/com/ays/theatre/crawler/core/dao/TheatrePlayDao.java
@@ -13,6 +13,7 @@ import org.jooq.DSLContext;
 import com.ays.theatre.crawler.Tables;
 import com.ays.theatre.crawler.core.model.ChangeAction;
 import com.ays.theatre.crawler.core.model.ImmutableTheatrePlayObject;
+import com.ays.theatre.crawler.core.utils.Origin;
 import com.ays.theatre.crawler.tables.records.TheatrePlayDetailsRecord;
 import com.ays.theatre.crawler.tables.records.TheatrePlayRecord;
 import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgTicketPayload;
@@ -102,29 +103,29 @@ public class TheatrePlayDao {
                 .fetchOneInto(TheatrePlayDetailsRecord.class));
     }
 
-    public List<String> getTheatrePlaysByOrigin(String origin, OffsetDateTime dateTime) {
+    public List<String> getTheatrePlaysByOrigin(Origin origin, OffsetDateTime dateTime) {
         return dslContext.selectDistinct(Tables.THEATRE_PLAY.URL)
                 .from(Tables.THEATRE_PLAY)
-                .where(Tables.THEATRE_PLAY.ORIGIN.eq(origin))
+                .where(Tables.THEATRE_PLAY.ORIGIN.eq(origin.getOrigin()))
                 .and(Tables.THEATRE_PLAY.DATE.greaterOrEqual(dateTime))
                 .orderBy(Tables.THEATRE_PLAY.URL.asc())
                 .fetchInto(String.class);
     }
 
-    public List<OffsetDateTime> getDatesOfPlaysByOriginAndUrl(String origin, String url) {
+    public List<OffsetDateTime> getDatesOfPlaysByOriginAndUrl(Origin origin, String url) {
         return dslContext.select(Tables.THEATRE_PLAY.DATE)
                 .from(Tables.THEATRE_PLAY)
-                .where(Tables.THEATRE_PLAY.ORIGIN.eq(origin))
+                .where(Tables.THEATRE_PLAY.ORIGIN.eq(origin.getOrigin()))
                 .and(Tables.THEATRE_PLAY.URL.eq(url))
                 .fetchInto(OffsetDateTime.class);
     }
 
-    public int updatePlayTicketLink(ImmutableTheatreArtBgTicketPayload payload, String origin) {
+    public int updatePlayTicketLink(ImmutableTheatreArtBgTicketPayload payload, Origin origin) {
         return dslContext.update(Tables.THEATRE_PLAY)
                 .set(Tables.THEATRE_PLAY.TICKETS_URL, payload.getTicketUrl())
                 .where(Tables.THEATRE_PLAY.URL.eq(payload.getUrl()))
                 .and(Tables.THEATRE_PLAY.DATE.eq(payload.getDate()))
-                .and(Tables.THEATRE_PLAY.ORIGIN.eq(origin))
+                .and(Tables.THEATRE_PLAY.ORIGIN.eq(origin.getOrigin()))
                 .execute();
     }
 

--- a/src/main/java/com/ays/theatre/crawler/core/resources/TheatrePlayResource.java
+++ b/src/main/java/com/ays/theatre/crawler/core/resources/TheatrePlayResource.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.ays.theatre.crawler.core.dao.TheatrePlayDao;
 import com.ays.theatre.crawler.core.utils.Constants;
+import com.ays.theatre.crawler.core.utils.Origin;
 import com.ays.theatre.crawler.theatreartbg.job.TheatreArtBgRunner;
 
 import jakarta.ws.rs.GET;
@@ -26,7 +27,7 @@ public class TheatrePlayResource {
     @GET
     @Path("/all")
     public List<String> getTheatrePlays() {
-        return theatrePlayDao.getTheatrePlaysByOrigin(Constants.THEATRE_ART_BG_ORIGIN, OffsetDateTime.now());
+        return theatrePlayDao.getTheatrePlaysByOrigin(Origin.THEATRE_ART_BG, OffsetDateTime.now());
     }
 
     @POST

--- a/src/main/java/com/ays/theatre/crawler/core/utils/Constants.java
+++ b/src/main/java/com/ays/theatre/crawler/core/utils/Constants.java
@@ -3,8 +3,6 @@ package com.ays.theatre.crawler.core.utils;
 public class Constants {
     public  static final String THEATRE_ART_BG_BASE_URL = "https://theatre.art.bg/";
 
-    public  static final String THEATRE_ART_BG_ORIGIN = "theatre.art.bg";
-
     public static final String THEATRE_ART_BG_DAY_LATCH = "THEATRE_ART_BG_DAY_LATCH";
 
     public static final String THEATRE_ART_BG_PLAY_LATCH = "THEATRE_ART_BG_PLAY_LATCH";

--- a/src/main/java/com/ays/theatre/crawler/core/utils/Origin.java
+++ b/src/main/java/com/ays/theatre/crawler/core/utils/Origin.java
@@ -1,0 +1,15 @@
+package com.ays.theatre.crawler.core.utils;
+
+public enum Origin {
+    THEATRE_ART_BG("theatre.art.bg");
+
+    private final String origin;
+
+    Origin(String origin) {
+        this.origin = origin;
+    }
+
+    public String getOrigin() {
+        return this.origin;
+    }
+}

--- a/src/main/java/com/ays/theatre/crawler/job/PeriodicRunner.java
+++ b/src/main/java/com/ays/theatre/crawler/job/PeriodicRunner.java
@@ -1,5 +1,6 @@
 package com.ays.theatre.crawler.job;
 
+import com.ays.theatre.crawler.calendar.resync.GoogleCalendarReSyncService;
 import com.ays.theatre.crawler.theatreartbg.job.TheatreArtBgRunner;
 
 import io.quarkus.scheduler.Scheduled;
@@ -9,13 +10,20 @@ import jakarta.enterprise.context.ApplicationScoped;
 public class PeriodicRunner {
 
     private final TheatreArtBgRunner theatreArtBgRunner;
+    private final GoogleCalendarReSyncService googleCalendarReSyncService;
 
-    public PeriodicRunner(TheatreArtBgRunner theatreArtBgRunner) {
+    public PeriodicRunner(TheatreArtBgRunner theatreArtBgRunner,
+                          GoogleCalendarReSyncService googleCalendarReSyncService) {
         this.theatreArtBgRunner = theatreArtBgRunner;
+        this.googleCalendarReSyncService = googleCalendarReSyncService;
     }
 
     @Scheduled(cron="0 */5 * * * ?")
     void runTheaterArtBgJob() {
+        // Resync in case the DB data was lost or the process is running on a new machine.
+        googleCalendarReSyncService.reSync();
+
+        // Run the scraper
         theatreArtBgRunner.run();
     }
 }

--- a/src/main/java/com/ays/theatre/crawler/theatreartbg/job/TheatreArtBgRunner.java
+++ b/src/main/java/com/ays/theatre/crawler/theatreartbg/job/TheatreArtBgRunner.java
@@ -15,6 +15,7 @@ import com.ays.theatre.crawler.calendar.model.ImmutableGoogleCalendarEventSchedu
 import com.ays.theatre.crawler.core.dao.TheatrePlayDao;
 import com.ays.theatre.crawler.core.service.LatchService;
 import com.ays.theatre.crawler.core.utils.Constants;
+import com.ays.theatre.crawler.core.utils.Origin;
 import com.ays.theatre.crawler.core.utils.PageUtils;
 import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgCalendar;
 import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgPlayObject;
@@ -105,7 +106,7 @@ public class TheatreArtBgRunner implements Runnable {
     }
 
     private void handleScrapingPlayDetails() {
-        var allPlayRecords = theatrePlayDao.getTheatrePlaysByOrigin(Constants.THEATRE_ART_BG_ORIGIN,
+        var allPlayRecords = theatrePlayDao.getTheatrePlaysByOrigin(Origin.THEATRE_ART_BG,
                                                                     OffsetDateTime.now());
 
         var playPayloads = allPlayRecords.stream().map(url ->
@@ -120,7 +121,7 @@ public class TheatreArtBgRunner implements Runnable {
 
     private void runCreatingGoogleCalendarEvents(OffsetDateTime today) {
         googleCalendarEventSchedulerWorkerPool.startWorkers();
-        var recordsFromTodayOnwards = googleCalendarDao.getRecords(Constants.THEATRE_ART_BG_ORIGIN, today);
+        var recordsFromTodayOnwards = googleCalendarDao.getRecords(Origin.THEATRE_ART_BG, today);
         latchService.init(Constants.GOOGLE_CALENDAR_LATCH, recordsFromTodayOnwards.size());
         calendarQueue.addAll(recordsFromTodayOnwards);
         latchService.await(Constants.GOOGLE_CALENDAR_LATCH);

--- a/src/main/java/com/ays/theatre/crawler/theatreartbg/service/TheatreArtBgDayService.java
+++ b/src/main/java/com/ays/theatre/crawler/theatreartbg/service/TheatreArtBgDayService.java
@@ -4,6 +4,7 @@ import com.ays.theatre.crawler.core.dao.TheatrePlayDao;
 import com.ays.theatre.crawler.core.model.ImmutableTheatrePlayObject;
 import com.ays.theatre.crawler.core.service.LatchService;
 import com.ays.theatre.crawler.core.service.TheatreService;
+import com.ays.theatre.crawler.core.utils.Origin;
 import com.ays.theatre.crawler.tables.records.TheatrePlayRecord;
 import com.ays.theatre.crawler.core.utils.Constants;
 import com.ays.theatre.crawler.theatreartbg.model.*;
@@ -158,7 +159,7 @@ public class TheatreArtBgDayService implements TheatreService<ImmutableTheatreAr
                 .setTitle(play.getTitle())
                 .setUrl(play.getUrl())
                 .setTheatre(play.getTheatre())
-                .setOrigin(Constants.THEATRE_ART_BG_ORIGIN)
+                .setOrigin(Origin.THEATRE_ART_BG.getOrigin())
                 .setDate(localDateTime)
                 .setLastUpdated(OffsetDateTime.now(ZoneOffset.UTC));
     }

--- a/src/main/java/com/ays/theatre/crawler/theatreartbg/service/TheatreArtBgPlayService.java
+++ b/src/main/java/com/ays/theatre/crawler/theatreartbg/service/TheatreArtBgPlayService.java
@@ -5,6 +5,7 @@ import static com.ays.theatre.crawler.core.utils.DateUtils.BULGARIAN_MONTH_TO_CA
 import com.ays.theatre.crawler.core.dao.TheatrePlayDao;
 import com.ays.theatre.crawler.core.service.LatchService;
 import com.ays.theatre.crawler.core.service.TheatreService;
+import com.ays.theatre.crawler.core.utils.Origin;
 import com.ays.theatre.crawler.tables.records.TheatrePlayDetailsRecord;
 import com.ays.theatre.crawler.core.utils.Constants;
 import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgPlayObject;
@@ -56,7 +57,7 @@ public class TheatreArtBgPlayService implements TheatreService<ImmutableTheatreA
             // update the links to any offered tickets
             var ticketsLinks = getTicketsLinks(playInfo, url);
             ticketsLinks.forEach(
-                    payload -> theatrePlayDao.updatePlayTicketLink(payload, Constants.THEATRE_ART_BG_ORIGIN));
+                    payload -> theatrePlayDao.updatePlayTicketLink(payload, Origin.THEATRE_ART_BG));
         } catch (Exception ex) {
             LOG.error("An error occurred while trying to scrape " + url);
             throw new RuntimeException(ex);
@@ -133,7 +134,7 @@ public class TheatreArtBgPlayService implements TheatreService<ImmutableTheatreA
     }
 
     private List<ImmutableTheatreArtBgTicketPayload> getTicketsLinks(DomNode playInfo, String url) {
-        var dates = theatrePlayDao.getDatesOfPlaysByOriginAndUrl(Constants.THEATRE_ART_BG_ORIGIN, url);
+        var dates = theatrePlayDao.getDatesOfPlaysByOriginAndUrl(Origin.THEATRE_ART_BG, url);
         var dayAndMonthYToDateMap = dates.stream()
                 .collect(Collectors.toMap(
                         date -> String.format("%d-%d", date.getDayOfMonth(), date.getMonthValue()),
@@ -178,6 +179,6 @@ public class TheatreArtBgPlayService implements TheatreService<ImmutableTheatreA
                 .setRating(ratingAndVotes)
                 .setCrew(crewHtml)
                 .setDescription(descriptionHtml)
-                .setOrigin(Constants.THEATRE_ART_BG_ORIGIN);
+                .setOrigin(Origin.THEATRE_ART_BG.getOrigin());
     }
 }


### PR DESCRIPTION
Finish the re-sync implementation. The current implementation uses a simple approach of:
 - if there are no events in the DB - then read from today onwards and repopulate.
 - Improve Origin assignment via URL
 - Add re-syncing as part of the periodic runner