### PR TITLE
Improve checkpointing to reduce crawling and scraping efforts

### DIFF
--- a/src/main/java/com/ays/theatre/crawler/TheatreCrawlerApplication.java
+++ b/src/main/java/com/ays/theatre/crawler/TheatreCrawlerApplication.java
@@ -4,7 +4,13 @@ import java.time.OffsetDateTime;
 
 import com.ays.theatre.crawler.calendar.base.GoogleCalendarService;
 import com.ays.theatre.crawler.calendar.resync.GoogleCalendarReSyncService;
+import com.ays.theatre.crawler.core.service.LatchService;
+import com.ays.theatre.crawler.core.utils.Constants;
 import com.ays.theatre.crawler.theatreartbg.job.TheatreArtBgRunner;
+import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgCalendar;
+import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgPlayObject;
+import com.ays.theatre.crawler.theatreartbg.service.TheatreArtBgDayService;
+import com.ays.theatre.crawler.theatreartbg.service.TheatreArtBgPlayService;
 
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
@@ -17,22 +23,36 @@ public class TheatreCrawlerApplication implements QuarkusApplication {
     private final GoogleCalendarService googleCalendarService;
     private final GoogleCalendarReSyncService googleCalendarReSyncService;
 
+    private final TheatreArtBgPlayService theatreArtBgPlayService;
+    private final LatchService latchService;
+
     public TheatreCrawlerApplication(TheatreArtBgRunner theatreArtBgJob,
                                      GoogleCalendarService googleCalendarService,
-                                     GoogleCalendarReSyncService googleCalendarReSyncService) {
+                                     GoogleCalendarReSyncService googleCalendarReSyncService,
+                                     TheatreArtBgPlayService theatreArtBgPlayService,
+                                     LatchService latchService) {
         this.theatreArtBgJob = theatreArtBgJob;
         this.googleCalendarService = googleCalendarService;
         this.googleCalendarReSyncService = googleCalendarReSyncService;
+        this.theatreArtBgPlayService = theatreArtBgPlayService;
+        this.latchService = latchService;
     }
 
     @Override
     public int run(String... args) {
-        var allEvents = googleCalendarService.getAllEvents(OffsetDateTime.now());
-        googleCalendarService.delete(allEvents);
-
-        googleCalendarReSyncService.reSync();
-
+//        var allEvents = googleCalendarService.getAllEvents(OffsetDateTime.now());
+//        googleCalendarService.delete(allEvents);
+//
+//        googleCalendarReSyncService.reSync();
+//
         theatreArtBgJob.run();
+
+
+//        latchService.init(Constants.THEATRE_ART_BG_PLAY_LATCH, 1);
+//        theatreArtBgPlayService.scrape(ImmutableTheatreArtBgPlayObject.builder().build(),
+//                                       "https://theatre.art.bg/урок-по-български_5876_6_20",
+//                                       OffsetDateTime.now());
+//        latchService.await(Constants.THEATRE_ART_BG_PLAY_LATCH);
 
         return 0;
     }

--- a/src/main/java/com/ays/theatre/crawler/calendar/base/GoogleCalendarEventSchedulerWorkerPool.java
+++ b/src/main/java/com/ays/theatre/crawler/calendar/base/GoogleCalendarEventSchedulerWorkerPool.java
@@ -25,9 +25,7 @@ public class GoogleCalendarEventSchedulerWorkerPool extends WorkerPool<GoogleCal
             GoogleCalendarService googleCalendarService,
             GoogleCalendarDao dao,
             ConcurrentLinkedQueue<ImmutableGoogleCalendarEventSchedulerPayload> queue,
-            LatchService latchService,
-            @Named(GOOGLE_CALENDAR_WORKER_QUEUE_SIZE) int poolSize) {
-        super(poolSize);
+            LatchService latchService) {
         this.googleCalendarService = googleCalendarService;
         this.dao = dao;
         this.queue = queue;

--- a/src/main/java/com/ays/theatre/crawler/core/dao/TheatrePlayDao.java
+++ b/src/main/java/com/ays/theatre/crawler/core/dao/TheatrePlayDao.java
@@ -75,6 +75,18 @@ public class TheatrePlayDao {
                 .set(record)
                 .execute();
     }
+
+    public int updateLastUpdated(
+            DSLContext dslContext, String url, OffsetDateTime playTime, Origin origin, OffsetDateTime lastUpdatedTime) {
+
+        return dslContext.update(Tables.THEATRE_PLAY)
+                .set(Tables.THEATRE_PLAY.LAST_UPDATED, lastUpdatedTime)
+                .where(Tables.THEATRE_PLAY.URL.eq(url))
+                .and(Tables.THEATRE_PLAY.DATE.eq(playTime))
+                .and(Tables.THEATRE_PLAY.ORIGIN.eq(origin.getOrigin()))
+                .execute();
+    }
+
     public int insertPlay(DSLContext dslContext, TheatrePlayRecord record) {
         return dslContext.insertInto(Tables.THEATRE_PLAY)
                 .set(record)
@@ -82,7 +94,7 @@ public class TheatrePlayDao {
                 .execute();
     }
 
-    public int upsertDetails(TheatrePlayDetailsRecord record) {
+    public int upsertDetails(DSLContext dslContext, TheatrePlayDetailsRecord record) {
         return dslContext.insertInto(Tables.THEATRE_PLAY_DETAILS)
                 .set(record)
                 .onDuplicateKeyUpdate()
@@ -108,6 +120,7 @@ public class TheatrePlayDao {
                 .from(Tables.THEATRE_PLAY)
                 .where(Tables.THEATRE_PLAY.ORIGIN.eq(origin.getOrigin()))
                 .and(Tables.THEATRE_PLAY.DATE.greaterOrEqual(dateTime))
+                .and(Tables.THEATRE_PLAY.DATE.greaterOrEqual(dateTime))
                 .orderBy(Tables.THEATRE_PLAY.URL.asc())
                 .fetchInto(String.class);
     }
@@ -120,7 +133,7 @@ public class TheatrePlayDao {
                 .fetchInto(OffsetDateTime.class);
     }
 
-    public int updatePlayTicketLink(ImmutableTheatreArtBgTicketPayload payload, Origin origin) {
+    public int updatePlayTicketLink(DSLContext dslContext, ImmutableTheatreArtBgTicketPayload payload, Origin origin) {
         return dslContext.update(Tables.THEATRE_PLAY)
                 .set(Tables.THEATRE_PLAY.TICKETS_URL, payload.getTicketUrl())
                 .where(Tables.THEATRE_PLAY.URL.eq(payload.getUrl()))

--- a/src/main/java/com/ays/theatre/crawler/core/service/ScrapeService.java
+++ b/src/main/java/com/ays/theatre/crawler/core/service/ScrapeService.java
@@ -1,0 +1,8 @@
+package com.ays.theatre.crawler.core.service;
+
+import java.time.OffsetDateTime;
+
+public interface ScrapeService<T> {
+
+    void scrape(T obj, String url, OffsetDateTime scrapeStartTime);
+}

--- a/src/main/java/com/ays/theatre/crawler/core/service/TheatreService.java
+++ b/src/main/java/com/ays/theatre/crawler/core/service/TheatreService.java
@@ -1,6 +1,0 @@
-package com.ays.theatre.crawler.core.service;
-
-public interface TheatreService<T> {
-
-    void scrape(T obj, String url);
-}

--- a/src/main/java/com/ays/theatre/crawler/core/service/WorkerPool.java
+++ b/src/main/java/com/ays/theatre/crawler/core/service/WorkerPool.java
@@ -5,17 +5,15 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class WorkerPool<W extends WorkerI> {
-    private final int poolSize;
     private final List<W> workers;
     private final AtomicBoolean started;
 
-    public WorkerPool(int poolSize) {
-        this.poolSize = poolSize;
+    public WorkerPool() {
         this.workers = new ArrayList<>();
         this.started = new AtomicBoolean(false);
     }
 
-    public void startWorkers() {
+    public void startWorkers(int poolSize) {
         if (started.get()) {
             throw new IllegalCallerException("Workers already started");
         }

--- a/src/main/java/com/ays/theatre/crawler/job/PeriodicRunner.java
+++ b/src/main/java/com/ays/theatre/crawler/job/PeriodicRunner.java
@@ -18,7 +18,7 @@ public class PeriodicRunner {
         this.googleCalendarReSyncService = googleCalendarReSyncService;
     }
 
-    @Scheduled(cron="0 */5 * * * ?")
+//    @Scheduled(cron="0 */5 * * * ?")
     void runTheaterArtBgJob() {
         // Resync in case the DB data was lost or the process is running on a new machine.
         googleCalendarReSyncService.reSync();

--- a/src/main/java/com/ays/theatre/crawler/theatreartbg/model/TheatreArtQueuePayload.java
+++ b/src/main/java/com/ays/theatre/crawler/theatreartbg/model/TheatreArtQueuePayload.java
@@ -1,8 +1,8 @@
 package com.ays.theatre.crawler.theatreartbg.model;
 
-import org.immutables.value.Value;
+import java.time.OffsetDateTime;
 
-import com.ays.theatre.crawler.core.service.TheatreService;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public interface TheatreArtQueuePayload {
@@ -10,4 +10,6 @@ public interface TheatreArtQueuePayload {
     Object getObject();
 
     String getUrl();
+
+    OffsetDateTime getScrapingStartTime();
 }

--- a/src/main/java/com/ays/theatre/crawler/theatreartbg/service/TheatreArtBgPlayService.java
+++ b/src/main/java/com/ays/theatre/crawler/theatreartbg/service/TheatreArtBgPlayService.java
@@ -1,44 +1,61 @@
 package com.ays.theatre.crawler.theatreartbg.service;
 
+import static com.ays.theatre.crawler.Configuration.CUSTOM_DSL;
 import static com.ays.theatre.crawler.core.utils.DateUtils.BULGARIAN_MONTH_TO_CALENDAR_MONTH_MAP;
 
 import com.ays.theatre.crawler.core.dao.TheatrePlayDao;
 import com.ays.theatre.crawler.core.service.LatchService;
-import com.ays.theatre.crawler.core.service.TheatreService;
+import com.ays.theatre.crawler.core.service.ScrapeService;
+import com.ays.theatre.crawler.core.utils.DateUtils;
 import com.ays.theatre.crawler.core.utils.Origin;
 import com.ays.theatre.crawler.tables.records.TheatrePlayDetailsRecord;
 import com.ays.theatre.crawler.core.utils.Constants;
 import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgPlayObject;
 import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgTicketPayload;
 import com.ays.theatre.crawler.core.utils.PageUtils;
+
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.htmlunit.WebClient;
 import org.htmlunit.html.*;
 import org.jboss.logging.Logger;
+import org.jooq.DSLContext;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Singleton
-public class TheatreArtBgPlayService implements TheatreService<ImmutableTheatreArtBgPlayObject> {
+public class TheatreArtBgPlayService implements ScrapeService<ImmutableTheatreArtBgPlayObject> {
     private static final Logger LOG = Logger.getLogger(TheatreArtBgPlayService.class);
 
     private final TheatrePlayDao theatrePlayDao;
     private final LatchService latchService;
+    private final DSLContext dslContext;
 
-    public TheatreArtBgPlayService(TheatrePlayDao theatrePlayDao, LatchService latchService) {
+    public TheatreArtBgPlayService(
+            TheatrePlayDao theatrePlayDao,
+            LatchService latchService,
+            @Named(CUSTOM_DSL) DSLContext dslContext) {
         this.theatrePlayDao = theatrePlayDao;
         this.latchService = latchService;
+        this.dslContext = dslContext;
     }
 
     @Override
-    public void scrape(ImmutableTheatreArtBgPlayObject obj,  String url) {
+    public void scrape(ImmutableTheatreArtBgPlayObject obj, String url, OffsetDateTime scrapeStartTime) {
+        HtmlPage page = null;
         try (WebClient webClient = new WebClient()) {
             LOG.info(String.format("[%s] Will try to get a connection", url));
             configureWebClient(webClient);
-            HtmlPage page = PageUtils.navigateWithRetry(webClient, url);
+            page = PageUtils.navigateWithRetry(webClient, url);
             LOG.info(String.format("[%s] Will get play info ", url));
             var playInfo = page.querySelectorAll("div.actior").getFirst();
 
@@ -49,19 +66,25 @@ public class TheatreArtBgPlayService implements TheatreService<ImmutableTheatreA
             LOG.info(String.format("[%s] Got play crew", url));
 
             var ratingAndVotes = getRatingAndVotes(page);
-
-            var record = getPlayRecord(url, ratingAndVotes, crewHtml, descriptionHtml);
-            LOG.info(String.format("[%s] Storing result", url));
-            theatrePlayDao.upsertDetails(record);
-
             // update the links to any offered tickets
             var ticketsLinks = getTicketsLinks(playInfo, url);
-            ticketsLinks.forEach(
-                    payload -> theatrePlayDao.updatePlayTicketLink(payload, Origin.THEATRE_ART_BG));
+
+            dslContext.transaction(tx -> {
+                var dslContext = tx.dsl();
+                var record = getPlayRecord(scrapeStartTime, url, ratingAndVotes, crewHtml, descriptionHtml);
+                LOG.info(String.format("[%s] Storing result", url));
+                theatrePlayDao.upsertDetails(dslContext, record);
+
+                ticketsLinks.forEach(
+                        payload -> theatrePlayDao.updatePlayTicketLink(dslContext, payload, Origin.THEATRE_ART_BG));
+            });
         } catch (Exception ex) {
             LOG.error("An error occurred while trying to scrape " + url);
             throw new RuntimeException(ex);
         } finally {
+            if (Objects.nonNull(page)) {
+                page.cleanUp();
+            }
             latchService.countDown(Constants.THEATRE_ART_BG_PLAY_LATCH);
             LOG.info(String.format("[%s] Finished scraping", url));
         }
@@ -133,35 +156,74 @@ public class TheatreArtBgPlayService implements TheatreService<ImmutableTheatreA
                 .replaceAll("\u0000", "");
     }
 
+    // TODO: Find a way to calculate the year based on the month
     private List<ImmutableTheatreArtBgTicketPayload> getTicketsLinks(DomNode playInfo, String url) {
         var dates = theatrePlayDao.getDatesOfPlaysByOriginAndUrl(Origin.THEATRE_ART_BG, url);
-        var dayAndMonthYToDateMap = dates.stream()
-                .collect(Collectors.toMap(
-                        date -> String.format("%d-%d", date.getDayOfMonth(), date.getMonthValue()),
-                        Function.identity()));
 
         var playTicketsDomNodeList = playInfo.querySelectorAll("td.ptd_predi");
-        return playTicketsDomNodeList.stream().map(ticketRow -> {
-            var ticketLink = ticketRow.querySelector("a.times\\ link_kupi_bilet");
-            if (ticketLink == null) {
-                return null;
-            }
-            var dayAndMonth = ticketRow.querySelector("div.mesec_data").getChildNodes();
-            var day = Integer.parseInt(dayAndMonth.get(0).getTextContent());
-            var month = dayAndMonth.get(1).getTextContent();
-            var monthNumber = BULGARIAN_MONTH_TO_CALENDAR_MONTH_MAP.get(month.toLowerCase());
-            var dateTime = dayAndMonthYToDateMap.get(String.format("%d-%d", day, monthNumber));
-            if (dateTime == null) {
-                LOG.error(String.format("Failed to locate ticket url for %s and date %s %s", url, day, month));
-                return null;
-            }
-            var ticketUrl = ticketLink.getAttributes().getNamedItem("href").getTextContent();
-            return ImmutableTheatreArtBgTicketPayload.builder()
-                    .url(url)
-                    .date(dateTime)
-                    .ticketUrl(String.format("%s%s", Constants.THEATRE_ART_BG_BASE_URL, ticketUrl))
-                    .build();
-        }).filter(Objects::nonNull).collect(Collectors.toList());
+        return playTicketsDomNodeList.stream()
+                .flatMap(ticketRow -> extractTicketMetadata(url, ticketRow))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private Stream<ImmutableTheatreArtBgTicketPayload> extractTicketMetadata(String url, DomNode ticketRow) {
+        var ticketLink = ticketRow.querySelector("a.times\\ link_kupi_bilet");
+        if (ticketLink == null) {
+            return null;
+        }
+        var ticketUrl = ticketLink.getAttributes().getNamedItem("href").getTextContent();
+
+        var dayAndMonth = ticketRow.querySelector("div.mesec_data").getChildNodes();
+        var day = Integer.parseInt(dayAndMonth.get(0).getTextContent());
+        var month = dayAndMonth.get(1).getTextContent();
+        var monthNumber = BULGARIAN_MONTH_TO_CALENDAR_MONTH_MAP.get(month.toLowerCase());
+        var allTicketRows = ticketRow.querySelectorAll("table td");
+        return getAllTicketsForEachDay(url, allTicketRows, day, monthNumber, ticketUrl);
+    }
+
+    private Stream<ImmutableTheatreArtBgTicketPayload> getAllTicketsForEachDay(
+            String url,
+            DomNodeList<DomNode> allTicketRows,
+            int day,
+            Integer monthNumber,
+            String ticketUrl) {
+
+        return allTicketRows
+                .stream()
+                .flatMap(t -> t.getChildNodes().stream())
+                .filter(o -> o instanceof DomText)
+                .map(t -> t.getTextContent().trim())
+                .filter(t -> !Objects.equals(t, ""))
+                .map(dateTimeText ->
+                             getImmutableTheatreArtBgTicketPayload(url, dateTimeText, day, monthNumber, ticketUrl));
+    }
+
+    private ImmutableTheatreArtBgTicketPayload getImmutableTheatreArtBgTicketPayload(
+            String url,
+            String dateTimeText,
+            int day,
+            Integer month,
+            String ticketUrl) {
+
+        var date = OffsetDateTime.ofInstant(
+                DateUtils.getDateWithoutTimeUsingCalendar().toInstant(), ZoneId.of(Constants.TIMEZONE));
+        var year = date.getYear();
+        var hourAndMinute = dateTimeText.split(" ")[0];
+        if (!hourAndMinute.contains(".")) {
+            return null;
+        }
+        var hourAndMinuteParts = hourAndMinute.split("\\.");
+        var hour = Integer.parseInt(hourAndMinuteParts[0]) + 2; // FIXME
+        var minute = Integer.parseInt(hourAndMinuteParts[1]);
+        if (date.getMonthValue() > month) {
+            year++;
+        }
+        return ImmutableTheatreArtBgTicketPayload.builder()
+                .url(url)
+                .date(DateUtils.toOffsetDateTime(year, month, day, hour, minute))
+                .ticketUrl(String.format("%s%s", Constants.THEATRE_ART_BG_BASE_URL, ticketUrl))
+                .build();
     }
 
     private void configureWebClient(WebClient webClient) {
@@ -172,13 +234,18 @@ public class TheatreArtBgPlayService implements TheatreService<ImmutableTheatreA
         webClient.getOptions().setDownloadImages(false);
     }
 
-    private static TheatrePlayDetailsRecord getPlayRecord(String url, String ratingAndVotes, String crewHtml,
-                                                          String descriptionHtml) {
+    private TheatrePlayDetailsRecord getPlayRecord(
+            OffsetDateTime scrapeStartTime,
+            String url,
+            String ratingAndVotes,
+            String crewHtml,
+            String descriptionHtml) {
         return new TheatrePlayDetailsRecord()
                 .setUrl(url)
                 .setRating(ratingAndVotes)
                 .setCrew(crewHtml)
                 .setDescription(descriptionHtml)
-                .setOrigin(Origin.THEATRE_ART_BG.getOrigin());
+                .setOrigin(Origin.THEATRE_ART_BG.getOrigin())
+                .setLastUpdated(scrapeStartTime);
     }
 }

--- a/src/main/java/com/ays/theatre/crawler/theatreartbg/worker/TheatreArtBgScraperWorker.java
+++ b/src/main/java/com/ays/theatre/crawler/theatreartbg/worker/TheatreArtBgScraperWorker.java
@@ -1,13 +1,14 @@
 
 package com.ays.theatre.crawler.theatreartbg.worker;
 
+import java.time.OffsetDateTime;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.time.StopWatch;
 import org.jboss.logging.Logger;
 
-import com.ays.theatre.crawler.core.service.TheatreService;
+import com.ays.theatre.crawler.core.service.ScrapeService;
 import com.ays.theatre.crawler.core.service.Worker;
 import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgCalendar;
 import com.ays.theatre.crawler.theatreartbg.model.ImmutableTheatreArtBgPlayObject;
@@ -37,11 +38,11 @@ public class TheatreArtBgScraperWorker extends Worker<ImmutableTheatreArtQueuePa
             if (payload.getObject() instanceof ImmutableTheatreArtBgCalendar) { // FIXME - custom object
                 LOG.info(String.format("[%d] ==> Visiting Day URL: %s", getId(), payload.getUrl()));
                 scrapeAndTime(theatreArtBgDayService, (ImmutableTheatreArtBgCalendar) payload.getObject(),
-                        payload.getUrl());
+                        payload.getUrl(), payload.getScrapingStartTime());
             } else if (payload.getObject() instanceof ImmutableTheatreArtBgPlayObject) {
                 LOG.info(String.format("[%d] ==> Visiting PLAY URL: %s", getId(), payload.getUrl()));
                 scrapeAndTime(theatreArtBgPlayService, (ImmutableTheatreArtBgPlayObject) payload.getObject(),
-                        payload.getUrl());
+                        payload.getUrl(), payload.getScrapingStartTime());
             } else {
                 LOG.error("No matching service for " + payload.getUrl());
             }
@@ -51,11 +52,11 @@ public class TheatreArtBgScraperWorker extends Worker<ImmutableTheatreArtQueuePa
         }
     }
 
-    private <T> void scrapeAndTime(TheatreService<T> service, T obj, String url) {
+    private <T> void scrapeAndTime(ScrapeService<T> service, T obj, String url, OffsetDateTime scrapeStartTime) {
         var stopWatch = new StopWatch();
         stopWatch.start();
         try {
-            service.scrape(obj, url);
+            service.scrape(obj, url, scrapeStartTime);
         } catch (Exception ex) {
             LOG.error(ex);
         } finally {

--- a/src/main/java/com/ays/theatre/crawler/theatreartbg/worker/TheatreArtBgScraperWorkerPool.java
+++ b/src/main/java/com/ays/theatre/crawler/theatreartbg/worker/TheatreArtBgScraperWorkerPool.java
@@ -26,9 +26,7 @@ public class TheatreArtBgScraperWorkerPool extends WorkerPool<TheatreArtBgScrape
 
     public TheatreArtBgScraperWorkerPool(TheatreArtBgDayService theatreArtBgDayService,
                                          TheatreArtBgPlayService theatreArtBgPlayService,
-                                         ConcurrentLinkedQueue<ImmutableTheatreArtQueuePayload> queue,
-                                         @Named(THEATRE_ART_BG_WORKER_POOL_SIZE) int poolSize) {
-        super(poolSize);
+                                         ConcurrentLinkedQueue<ImmutableTheatreArtQueuePayload> queue) {
         this.theatreArtBgDayService = theatreArtBgDayService;
         this.theatreArtBgPlayService = theatreArtBgPlayService;
         this.queue = queue;

--- a/src/main/resources/migrations/sql/migrations.sql
+++ b/src/main/resources/migrations/sql/migrations.sql
@@ -27,6 +27,7 @@ create table if not exists theatre.theatre_play_details (
      crew                         text NULL,
      rating                       text NULL,
      origin                       text NULL,
+     last_updated                 timestamptz DEFAULT (now()),
      PRIMARY KEY (url)
 );
 


### PR DESCRIPTION
The purpose of this MR is to:
 - only scrape Day urls that haven't been scraped before. We still scrape the play page because there could be new tickets added to the new dates of the play.
 - only create events for Plays who don't have a Google Calendar Event associated with them.
 - Improve the logic for scraping the details of the play so that the OffsetDateTime can be calculated on its own.